### PR TITLE
Add aliases for commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddApplicantCommand.java
@@ -16,6 +16,7 @@ import seedu.address.model.person.Applicant;
 public class AddApplicantCommand extends Command {
 
     public static final String COMMAND_WORD = "addApplicant";
+    public static final String COMMAND_ALIAS = "adda";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an applicant to the applicant list. "
             + "\nParameters: "

--- a/src/main/java/seedu/address/logic/commands/AddMemberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMemberCommand.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.Member;
 public class AddMemberCommand extends Command {
 
     public static final String COMMAND_WORD = "addMember";
+    public static final String COMMAND_ALIAS = "addm";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a member to the member list. "
             + "\nParameters: "

--- a/src/main/java/seedu/address/logic/commands/DeleteApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteApplicantCommand.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.Applicant;
 public class DeleteApplicantCommand extends Command {
 
     public static final String COMMAND_WORD = "deleteApplicant";
+    public static final String COMMAND_ALIAS = "dela";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the applicant identified by the index number used in the displayed applicant list.\n"

--- a/src/main/java/seedu/address/logic/commands/DeleteMemberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMemberCommand.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.Member;
 public class DeleteMemberCommand extends Command {
 
     public static final String COMMAND_WORD = "deleteMember";
+    public static final String COMMAND_ALIAS = "delm";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the member identified by the index number used in the displayed member list.\n"

--- a/src/main/java/seedu/address/logic/commands/EditApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApplicantCommand.java
@@ -25,6 +25,7 @@ import seedu.address.model.person.fields.Phone;
 public class EditApplicantCommand extends Command {
 
     public static final String COMMAND_WORD = "editApplicant";
+    public static final String COMMAND_ALIAS = "edita";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the applicant identified "
             + "by the index number used in the displayed applicant list. "
@@ -81,7 +82,7 @@ public class EditApplicantCommand extends Command {
      * edited with {@code editApplicantDescriptor}.
      */
     private static Applicant createEditedApplicant(Applicant applicantToEdit,
-                                                   EditApplicantDescriptor editApplicantDescriptor) {
+            EditApplicantDescriptor editApplicantDescriptor) {
         assert applicantToEdit != null;
 
         Name updatedName = editApplicantDescriptor.getName().orElse(applicantToEdit.getName());

--- a/src/main/java/seedu/address/logic/commands/EditMemberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMemberCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.commands.AddMemberCommand.MESSAGE_DUPLICATE_MEMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -35,6 +34,7 @@ import seedu.address.model.tag.Tag;
 public class EditMemberCommand extends Command {
 
     public static final String COMMAND_WORD = "editMember";
+    public static final String COMMAND_ALIAS = "editm";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the member identified "
             + "by the index number used in the displayed member list. "

--- a/src/main/java/seedu/address/logic/commands/FindApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindApplicantCommand.java
@@ -8,7 +8,6 @@ import seedu.address.model.Model;
 import seedu.address.model.person.ApplicantContainsKeywordsPredicate;
 
 
-
 /**
  * Finds and lists all members in address book whose fields contains any of the argument keywords.
  * Keyword matching is case-insensitive.
@@ -16,6 +15,7 @@ import seedu.address.model.person.ApplicantContainsKeywordsPredicate;
 public class FindApplicantCommand extends Command {
 
     public static final String COMMAND_WORD = "findApplicant";
+    public static final String COMMAND_ALIAS = "finda";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all applicants whose information contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/address/logic/commands/FindMemberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindMemberCommand.java
@@ -8,7 +8,6 @@ import seedu.address.model.Model;
 import seedu.address.model.person.MemberContainsKeywordsPredicate;
 
 
-
 /**
  * Finds and lists all members in address book whose fields contains any of the argument keywords.
  * Keyword matching is case-insensitive.
@@ -16,6 +15,7 @@ import seedu.address.model.person.MemberContainsKeywordsPredicate;
 public class FindMemberCommand extends Command {
 
     public static final String COMMAND_WORD = "findMember";
+    public static final String COMMAND_ALIAS = "findm";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all members whose information contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/address/logic/commands/ViewApplicantsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewApplicantsCommand.java
@@ -9,7 +9,9 @@ import seedu.address.model.Model;
  * Lists all applicants in the address book to the user.
  */
 public class ViewApplicantsCommand extends Command {
+
     public static final String COMMAND_WORD = "viewApplicants";
+    public static final String COMMAND_ALIAS = "viewa";
 
     public static final String MESSAGE_SUCCESS = "Listed all applicants";
 

--- a/src/main/java/seedu/address/logic/commands/ViewMembersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewMembersCommand.java
@@ -9,7 +9,9 @@ import seedu.address.model.Model;
  * Lists all applicants in the address book to the user.
  */
 public class ViewMembersCommand extends Command {
+
     public static final String COMMAND_WORD = "viewMembers";
+    public static final String COMMAND_ALIAS = "viewm";
 
     public static final String MESSAGE_SUCCESS = "Listed all members";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -59,36 +59,46 @@ public class AddressBookParser {
         switch (commandWord) {
 
         case AddMemberCommand.COMMAND_WORD:
+        case AddMemberCommand.COMMAND_ALIAS:
             return new AddMemberCommandParser().parse(arguments);
 
         case AddApplicantCommand.COMMAND_WORD:
+        case AddApplicantCommand.COMMAND_ALIAS:
             return new AddApplicantCommandParser().parse(arguments);
 
         case EditMemberCommand.COMMAND_WORD:
+        case EditMemberCommand.COMMAND_ALIAS:
             return new EditMemberCommandParser().parse(arguments);
 
         case EditApplicantCommand.COMMAND_WORD:
+        case EditApplicantCommand.COMMAND_ALIAS:
             return new EditApplicantCommandParser().parse(arguments);
 
         case DeleteApplicantCommand.COMMAND_WORD:
+        case DeleteApplicantCommand.COMMAND_ALIAS:
             return new DeleteApplicantCommandParser().parse(arguments);
 
         case DeleteMemberCommand.COMMAND_WORD:
+        case DeleteMemberCommand.COMMAND_ALIAS:
             return new DeleteMemberCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
 
         case FindMemberCommand.COMMAND_WORD:
+        case FindMemberCommand.COMMAND_ALIAS:
             return new FindMemberCommandParser().parse(arguments);
 
         case FindApplicantCommand.COMMAND_WORD:
+        case FindApplicantCommand.COMMAND_ALIAS:
             return new FindApplicantCommandParser().parse(arguments);
 
         case ViewMembersCommand.COMMAND_WORD:
+        case ViewMembersCommand.COMMAND_ALIAS:
             return new ViewMembersCommand();
 
         case ViewApplicantsCommand.COMMAND_WORD:
+        case ViewApplicantsCommand.COMMAND_ALIAS:
             return new ViewApplicantsCommand();
 
         case ExitCommand.COMMAND_WORD:


### PR DESCRIPTION
Right now, many command names are long and inconvenient to type. I added a constant COMMAND_ALIAS in these command classes and AddressBookParser would recognise both it and COMMAND_WORD to return the same command.

We may have to change some messages and the UG to reflect and highlight this change.