### PR TITLE
Add Interview Time to Applicants

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApplicantCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;

--- a/src/main/java/seedu/address/logic/commands/EditApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApplicantCommand.java
@@ -1,8 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
@@ -16,6 +15,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Applicant;
+import seedu.address.model.person.fields.InterviewTime;
 import seedu.address.model.person.fields.Name;
 import seedu.address.model.person.fields.Phone;
 
@@ -32,7 +32,8 @@ public class EditApplicantCommand extends Command {
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_NAME + " {applicantName} "
-            + PREFIX_PHONE + " {phoneNumber} \n"
+            + PREFIX_PHONE + " {phoneNumber} "
+            + PREFIX_INTERVIEW + "{interviewTime}\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_NAME + " Johnny Doe "
             + PREFIX_PHONE + " 91234567";
@@ -87,8 +88,13 @@ public class EditApplicantCommand extends Command {
 
         Name updatedName = editApplicantDescriptor.getName().orElse(applicantToEdit.getName());
         Phone updatedPhone = editApplicantDescriptor.getPhone().orElse(applicantToEdit.getPhone());
+        InterviewTime updatedInterviewTime = editApplicantDescriptor.getInterviewTime()
+                .orElse(applicantToEdit.getInterviewTime());
 
-        return new Applicant(updatedName, updatedPhone);
+        Applicant newApplicant = new Applicant(updatedName, updatedPhone);
+        newApplicant.addInterviewTime(updatedInterviewTime);
+
+        return newApplicant;
     }
 
     @Override
@@ -122,6 +128,7 @@ public class EditApplicantCommand extends Command {
     public static class EditApplicantDescriptor {
         private Name name;
         private Phone phone;
+        private InterviewTime interviewTime;
 
         public EditApplicantDescriptor() {
         }
@@ -133,13 +140,14 @@ public class EditApplicantCommand extends Command {
         public EditApplicantDescriptor(EditApplicantDescriptor toCopy) {
             setName(toCopy.name);
             setPhone(toCopy.phone);
+            setInterviewTime(toCopy.interviewTime);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone);
+            return CollectionUtil.isAnyNonNull(name, phone, interviewTime);
         }
 
         public void setName(Name name) {
@@ -158,6 +166,14 @@ public class EditApplicantCommand extends Command {
             return Optional.ofNullable(phone);
         }
 
+        public void setInterviewTime(InterviewTime interviewTime) {
+            this.interviewTime = interviewTime;
+        }
+
+        public Optional<InterviewTime> getInterviewTime() {
+            return Optional.ofNullable(interviewTime);
+        }
+
         @Override
         public boolean equals(Object other) {
             if (other == this) {
@@ -171,7 +187,8 @@ public class EditApplicantCommand extends Command {
 
             EditApplicantDescriptor otherEditApplicantDescriptor = (EditApplicantDescriptor) other;
             return Objects.equals(name, otherEditApplicantDescriptor.name)
-                    && Objects.equals(phone, otherEditApplicantDescriptor.phone);
+                    && Objects.equals(phone, otherEditApplicantDescriptor.phone)
+                    && Objects.equals(interviewTime, otherEditApplicantDescriptor.interviewTime);
         }
 
         @Override
@@ -179,6 +196,7 @@ public class EditApplicantCommand extends Command {
             return new ToStringBuilder(this)
                     .add("name", name)
                     .add("phone", phone)
+                    .add("interview time", interviewTime)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,4 +13,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_TELEGRAM = new Prefix("/tele");
     public static final Prefix PREFIX_TAG = new Prefix("/tag");
 
+    public static final Prefix PREFIX_INTERVIEW = new Prefix("/interview");
+
 }

--- a/src/main/java/seedu/address/logic/parser/EditApplicantCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditApplicantCommandParser.java
@@ -2,8 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditApplicantCommand;
@@ -24,7 +23,7 @@ public class EditApplicantCommandParser implements Parser<EditApplicantCommand> 
     public EditApplicantCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_INTERVIEW);
 
         Index index;
 
@@ -35,7 +34,7 @@ public class EditApplicantCommandParser implements Parser<EditApplicantCommand> 
                     EditApplicantCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_INTERVIEW);
 
         EditApplicantDescriptor editApplicantDescriptor = new EditApplicantDescriptor();
 
@@ -44,6 +43,11 @@ public class EditApplicantCommandParser implements Parser<EditApplicantCommand> 
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
             editApplicantDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_INTERVIEW).isPresent()) {
+            editApplicantDescriptor.setInterviewTime(ParserUtil
+                    .parseInterviewTime(argMultimap.getValue(PREFIX_INTERVIEW).get()));
         }
 
         if (!editApplicantDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/address/logic/parser/EditApplicantCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditApplicantCommandParser.java
@@ -2,7 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditApplicantCommand;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,8 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -69,10 +67,7 @@ public class ParserUtil {
         if (!InterviewTime.isValidTime(trimmedTime)) {
             throw new ParseException(InterviewTime.MESSAGE_CONSTRAINTS);
         }
-
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
-        LocalDateTime dateTime = LocalDateTime.parse(trimmedTime, formatter);
-        return new InterviewTime(dateTime);
+        return new InterviewTime(trimmedTime);
 
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -14,6 +16,7 @@ import seedu.address.model.person.fields.Email;
 import seedu.address.model.person.fields.Name;
 import seedu.address.model.person.fields.Phone;
 import seedu.address.model.person.fields.Telegram;
+import seedu.address.model.person.fields.InterviewTime;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -49,6 +52,23 @@ public class ParserUtil {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
         return new Name(trimmedName);
+    }
+
+    /**
+     * Parses a {@code String interviewTime into a {@code InterviewTime}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code interviewTime} is invalid.
+     */
+    public static InterviewTime parseInterviewTime(String interviewTime) throws ParseException {
+        requireNonNull(interviewTime);
+        String trimmedTime = interviewTime.trim();
+        if (!InterviewTime.isValidTime(trimmedTime)) {
+            throw new ParseException(InterviewTime.MESSAGE_CONSTRAINTS);
+        }
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
+        LocalDateTime dateTime = LocalDateTime.parse(trimmedTime, formatter);
+        return new InterviewTime(dateTime);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -17,7 +17,6 @@ import seedu.address.model.person.fields.InterviewTime;
 import seedu.address.model.person.fields.Name;
 import seedu.address.model.person.fields.Phone;
 import seedu.address.model.person.fields.Telegram;
-
 import seedu.address.model.tag.Tag;
 
 /**
@@ -70,9 +69,13 @@ public class ParserUtil {
         if (!InterviewTime.isValidTime(trimmedTime)) {
             throw new ParseException(InterviewTime.MESSAGE_CONSTRAINTS);
         }
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
-        LocalDateTime dateTime = LocalDateTime.parse(trimmedTime, formatter);
-        return new InterviewTime(dateTime);
+        if (trimmedTime == "cancel") {
+            return InterviewTime.createEmptyInterviewTime();
+        } else {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
+            LocalDateTime dateTime = LocalDateTime.parse(trimmedTime, formatter);
+            return new InterviewTime(dateTime);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -13,10 +13,11 @@ import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.fields.Address;
 import seedu.address.model.person.fields.Email;
+import seedu.address.model.person.fields.InterviewTime;
 import seedu.address.model.person.fields.Name;
 import seedu.address.model.person.fields.Phone;
 import seedu.address.model.person.fields.Telegram;
-import seedu.address.model.person.fields.InterviewTime;
+
 import seedu.address.model.tag.Tag;
 
 /**
@@ -55,11 +56,14 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String interviewTime into a {@code InterviewTime}.
+     * Parses a {@code String interviewTime} into an {@code InterviewTime}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code interviewTime} is invalid.
+     * @param interviewTime A valid interview time string.
+     * @return An {@code InterviewTime} object representing the parsed time.
+     * @throws ParseException if the given {@code interviewTime} is invalid or cannot be parsed.
      */
+
     public static InterviewTime parseInterviewTime(String interviewTime) throws ParseException {
         requireNonNull(interviewTime);
         String trimmedTime = interviewTime.trim();

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -69,13 +69,11 @@ public class ParserUtil {
         if (!InterviewTime.isValidTime(trimmedTime)) {
             throw new ParseException(InterviewTime.MESSAGE_CONSTRAINTS);
         }
-        if (trimmedTime == "cancel") {
-            return InterviewTime.createEmptyInterviewTime();
-        } else {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
-            LocalDateTime dateTime = LocalDateTime.parse(trimmedTime, formatter);
-            return new InterviewTime(dateTime);
-        }
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
+        LocalDateTime dateTime = LocalDateTime.parse(trimmedTime, formatter);
+        return new InterviewTime(dateTime);
+
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Applicant.java
+++ b/src/main/java/seedu/address/model/person/Applicant.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.fields.InterviewTime;
 import seedu.address.model.person.fields.Name;
 import seedu.address.model.person.fields.Phone;
 
@@ -14,6 +15,8 @@ public class Applicant extends Person {
 
     private final Phone phone;
 
+    private InterviewTime interviewTime;
+
     /**
      * Every field must be present and not null.
      *
@@ -23,6 +26,7 @@ public class Applicant extends Person {
     public Applicant(Name name, Phone phone) {
         super(name);
         this.phone = phone;
+        this.interviewTime = InterviewTime.createEmptyInterviewTime();
     }
 
     /**
@@ -50,6 +54,12 @@ public class Applicant extends Person {
         return phone;
     }
 
+    public InterviewTime getInterviewTime() { return interviewTime; }
+
+    public void addInterviewTime(InterviewTime interviewTime) {
+        this.interviewTime = interviewTime;
+    }
+
     /**
      * Returns true if both applicants have the same identity and data fields.
      * This defines a stronger notion of equality between two applicants.
@@ -61,13 +71,14 @@ public class Applicant extends Person {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof Applicant)) {
+        if (!(other instanceof Applicant)    ){
             return false;
         }
 
         Applicant otherApplicant = (Applicant) other;
         return getName().equals(otherApplicant.getName())
-                && this.phone.equals(otherApplicant.phone);
+                && this.phone.equals(otherApplicant.phone)
+                && this.interviewTime.equals(otherApplicant.interviewTime);
     }
 
     @Override
@@ -81,12 +92,13 @@ public class Applicant extends Person {
         return new ToStringBuilder(this)
                 .add("name", getName())
                 .add("phone", phone)
+                .add("interview time", interviewTime)
                 .toString();
     }
 
     @Override
     public String detailsToCopy() {
         return "Name: " + getName() + "\n"
-                + "Phone: " + phone;
+                + "Phone: " + phone + "Interview Time: " + interviewTime;
     }
 }

--- a/src/main/java/seedu/address/model/person/Applicant.java
+++ b/src/main/java/seedu/address/model/person/Applicant.java
@@ -101,6 +101,7 @@ public class Applicant extends Person {
     @Override
     public String detailsToCopy() {
         return "Name: " + getName() + "\n"
-                + "Phone: " + phone + "Interview Time: " + interviewTime;
+                + "Phone: " + getPhone() + "\n"
+                + "Interview Time: " + interviewTime;
     }
 }

--- a/src/main/java/seedu/address/model/person/Applicant.java
+++ b/src/main/java/seedu/address/model/person/Applicant.java
@@ -26,7 +26,7 @@ public class Applicant extends Person {
     public Applicant(Name name, Phone phone) {
         super(name);
         this.phone = phone;
-        this.interviewTime = InterviewTime.createEmptyInterviewTime();
+        this.interviewTime = new InterviewTime("Interview time has not been set");
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Applicant.java
+++ b/src/main/java/seedu/address/model/person/Applicant.java
@@ -54,7 +54,9 @@ public class Applicant extends Person {
         return phone;
     }
 
-    public InterviewTime getInterviewTime() { return interviewTime; }
+    public InterviewTime getInterviewTime() {
+        return interviewTime;
+    }
 
     public void addInterviewTime(InterviewTime interviewTime) {
         this.interviewTime = interviewTime;

--- a/src/main/java/seedu/address/model/person/Applicant.java
+++ b/src/main/java/seedu/address/model/person/Applicant.java
@@ -71,7 +71,7 @@ public class Applicant extends Person {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof Applicant)    ){
+        if (!(other instanceof Applicant)) {
             return false;
         }
 

--- a/src/main/java/seedu/address/model/person/fields/InterviewTime.java
+++ b/src/main/java/seedu/address/model/person/fields/InterviewTime.java
@@ -1,0 +1,58 @@
+package seedu.address.model.person.fields;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class InterviewTime {
+
+    LocalDateTime interviewTime;
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Interview time should be in the format of DD/MM/YYYY HHmm";
+
+    public static final String VALIDATION_REGEX = "^\\d{2}/\\d{2}/\\d{4} \\d{4}$";
+    public InterviewTime(LocalDateTime interviewTime){
+
+        this.interviewTime = interviewTime;
+    }
+
+    public static boolean isValidTime(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        InterviewTime otherInterviewTime = (InterviewTime) other;
+
+        return interviewTime.equals(otherInterviewTime.interviewTime);
+    }
+
+    @Override
+    public String toString() {
+        if (interviewTime == null) {
+            return "Interview time has not been set";
+        }
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d MMMM yyyy ha");
+        String formattedTime = interviewTime.format(formatter);
+        return formattedTime;
+    }
+
+    // Create an empty InterviewTime object
+    public static InterviewTime createEmptyInterviewTime() {
+        return new InterviewTime(null);
+    }
+
+    @Override
+    public int hashCode() {
+        return interviewTime.hashCode();
+    }
+
+
+}

--- a/src/main/java/seedu/address/model/person/fields/InterviewTime.java
+++ b/src/main/java/seedu/address/model/person/fields/InterviewTime.java
@@ -10,12 +10,12 @@ import java.time.format.DateTimeFormatter;
 public class InterviewTime {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Interview time should be in the format of DD/MM/YYYY HHmm. To cancel the interview, enter " +
-                    "'Interview time has not been set'(case sensitive)";
+            "Interview time should be in the format of DD/MM/YYYY HHmm. To cancel the interview, enter "
+                    + "'Interview time has not been set'(case sensitive)";
 
     public static final String VALIDATION_REGEX = "^\\d{2}/\\d{2}/\\d{4} \\d{4}$";
 
-    public String interviewTime;
+    public String time;
 
     /**
      * Constructs a {@code InterviewTime}.
@@ -23,9 +23,7 @@ public class InterviewTime {
      * @param interviewTime A valid interview time.
      */
     public InterviewTime(String interviewTime) {
-        //DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
-        //LocalDateTime dateTime = LocalDateTime.parse(interviewTime, formatter);
-        this.interviewTime = interviewTime;
+        this.time = interviewTime;
     }
 
     /**
@@ -47,16 +45,16 @@ public class InterviewTime {
 
         InterviewTime otherInterviewTime = (InterviewTime) other;
 
-        return interviewTime.equals(otherInterviewTime.interviewTime);
+        return time.equals(otherInterviewTime.time);
     }
 
     @Override
     public String toString() {
-        if (interviewTime.equals("Interview time has not been set")) {
+        if (time.equals("Interview time has not been set")) {
             return "Interview time has not been set";
         }
         DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
-        LocalDateTime dateTime = LocalDateTime.parse(this.interviewTime, inputFormatter);
+        LocalDateTime dateTime = LocalDateTime.parse(this.time, inputFormatter);
         DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy h:mma");
         String formattedDateTime = dateTime.format(outputFormatter);
         return "Interview scheduled at: " + formattedDateTime;
@@ -64,6 +62,6 @@ public class InterviewTime {
 
     @Override
     public int hashCode() {
-        return interviewTime.hashCode();
+        return time.hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/person/fields/InterviewTime.java
+++ b/src/main/java/seedu/address/model/person/fields/InterviewTime.java
@@ -30,7 +30,7 @@ public class InterviewTime {
      */
     public static boolean isValidTime(String test) {
 
-        return test.matches(VALIDATION_REGEX) || test.equals("cancel");
+        return test.matches(VALIDATION_REGEX);
     }
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/person/fields/InterviewTime.java
+++ b/src/main/java/seedu/address/model/person/fields/InterviewTime.java
@@ -15,7 +15,7 @@ public class InterviewTime {
 
     public static final String VALIDATION_REGEX = "^\\d{2}/\\d{2}/\\d{4} \\d{4}$";
 
-    public String time;
+    private String time;
 
     /**
      * Constructs a {@code InterviewTime}.
@@ -63,5 +63,9 @@ public class InterviewTime {
     @Override
     public int hashCode() {
         return time.hashCode();
+    }
+
+    public String getTime() {
+        return this.time;
     }
 }

--- a/src/main/java/seedu/address/model/person/fields/InterviewTime.java
+++ b/src/main/java/seedu/address/model/person/fields/InterviewTime.java
@@ -3,21 +3,34 @@ package seedu.address.model.person.fields;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-public class InterviewTime {
+/**
+ * Represents a Person's interview time in the address book.
+ */
 
-    LocalDateTime interviewTime;
+public class InterviewTime {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Interview time should be in the format of DD/MM/YYYY HHmm";
 
     public static final String VALIDATION_REGEX = "^\\d{2}/\\d{2}/\\d{4} \\d{4}$";
-    public InterviewTime(LocalDateTime interviewTime){
 
+    private LocalDateTime interviewTime;
+
+    /**
+     * Constructs a {@code InterviewTime}.
+     *
+     * @param interviewTime A valid interview time.
+     */
+    public InterviewTime(LocalDateTime interviewTime) {
         this.interviewTime = interviewTime;
     }
 
+    /**
+     * Returns true if a given string is a valid interview time.
+     */
     public static boolean isValidTime(String test) {
-        return test.matches(VALIDATION_REGEX);
+
+        return test.matches(VALIDATION_REGEX) || test.equals("cancel");
     }
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/person/fields/InterviewTime.java
+++ b/src/main/java/seedu/address/model/person/fields/InterviewTime.java
@@ -1,9 +1,9 @@
 package seedu.address.model.person.fields;
 
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Person's interview time in the address book.

--- a/src/main/java/seedu/address/model/person/fields/InterviewTime.java
+++ b/src/main/java/seedu/address/model/person/fields/InterviewTime.java
@@ -3,6 +3,8 @@ package seedu.address.model.person.fields;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 /**
  * Represents a Person's interview time in the address book.
  */
@@ -23,6 +25,7 @@ public class InterviewTime {
      * @param interviewTime A valid interview time.
      */
     public InterviewTime(String interviewTime) {
+        checkArgument(isValidTime(interviewTime), MESSAGE_CONSTRAINTS);
         this.time = interviewTime;
     }
 
@@ -39,7 +42,8 @@ public class InterviewTime {
             return true;
         }
 
-        if (other == null || getClass() != other.getClass()) {
+        //instanceof handles null
+        if (!(other instanceof InterviewTime)) {
             return false;
         }
 

--- a/src/main/java/seedu/address/model/person/fields/InterviewTime.java
+++ b/src/main/java/seedu/address/model/person/fields/InterviewTime.java
@@ -10,18 +10,21 @@ import java.time.format.DateTimeFormatter;
 public class InterviewTime {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Interview time should be in the format of DD/MM/YYYY HHmm";
+            "Interview time should be in the format of DD/MM/YYYY HHmm. To cancel the interview, enter " +
+                    "'Interview time has not been set'(case sensitive)";
 
     public static final String VALIDATION_REGEX = "^\\d{2}/\\d{2}/\\d{4} \\d{4}$";
 
-    private LocalDateTime interviewTime;
+    public String interviewTime;
 
     /**
      * Constructs a {@code InterviewTime}.
      *
      * @param interviewTime A valid interview time.
      */
-    public InterviewTime(LocalDateTime interviewTime) {
+    public InterviewTime(String interviewTime) {
+        //DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
+        //LocalDateTime dateTime = LocalDateTime.parse(interviewTime, formatter);
         this.interviewTime = interviewTime;
     }
 
@@ -30,7 +33,7 @@ public class InterviewTime {
      */
     public static boolean isValidTime(String test) {
 
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) || test.equals("Interview time has not been set");
     }
     @Override
     public boolean equals(Object other) {
@@ -49,23 +52,18 @@ public class InterviewTime {
 
     @Override
     public String toString() {
-        if (interviewTime == null) {
+        if (interviewTime.equals("Interview time has not been set")) {
             return "Interview time has not been set";
         }
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d MMMM yyyy ha");
-        String formattedTime = interviewTime.format(formatter);
-        return formattedTime;
-    }
-
-    // Create an empty InterviewTime object
-    public static InterviewTime createEmptyInterviewTime() {
-        return new InterviewTime(null);
+        DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
+        LocalDateTime dateTime = LocalDateTime.parse(this.interviewTime, inputFormatter);
+        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy h:mma");
+        String formattedDateTime = dateTime.format(outputFormatter);
+        return "Interview scheduled at: " + formattedDateTime;
     }
 
     @Override
     public int hashCode() {
         return interviewTime.hashCode();
     }
-
-
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedApplicant.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedApplicant.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Applicant;
+import seedu.address.model.person.fields.InterviewTime;
 import seedu.address.model.person.fields.Name;
 import seedu.address.model.person.fields.Phone;
 
@@ -17,7 +18,6 @@ public class JsonAdaptedApplicant {
 
     private final String name;
     private final String phone;
-
     private final String interviewTime;
 
     /**
@@ -37,7 +37,11 @@ public class JsonAdaptedApplicant {
     public JsonAdaptedApplicant(Applicant source) {
         name = source.getName().fullName;
         phone = source.getPhone().value;
-        interviewTime = source.getInterviewTime().toString();
+        if (source.getInterviewTime().interviewTime == null) {
+            interviewTime = "Interview time has not been set";
+        } else {
+            interviewTime = source.getInterviewTime().interviewTime;
+        }
     }
 
     /**
@@ -60,8 +64,24 @@ public class JsonAdaptedApplicant {
         if (!Phone.isValidPhone(phone)) {
             throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
         }
+
+        if (interviewTime == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    InterviewTime.class.getSimpleName()));
+        }
+
+        if (!InterviewTime.isValidTime(interviewTime)) {
+            throw new IllegalValueException(InterviewTime.MESSAGE_CONSTRAINTS);
+        }
+
         final Phone modelPhone = new Phone(phone);
 
-        return new Applicant(modelName, modelPhone);
+        final Applicant applicant = new Applicant(modelName, modelPhone);
+
+        if (this.interviewTime != null) {
+            final InterviewTime time = new InterviewTime(interviewTime);
+            applicant.addInterviewTime(time);
+        }
+        return applicant;
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedApplicant.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedApplicant.java
@@ -18,13 +18,17 @@ public class JsonAdaptedApplicant {
     private final String name;
     private final String phone;
 
+    private final String interviewTime;
+
     /**
      * Constructs a {@code JsonAdaptedApplicant} with the given applicant details.
      */
     @JsonCreator
-    public JsonAdaptedApplicant(@JsonProperty("name") String name, @JsonProperty("phone") String phone) {
+    public JsonAdaptedApplicant(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
+                                @JsonProperty("interviewTime") String interviewTime) {
         this.name = name;
         this.phone = phone;
+        this.interviewTime = interviewTime;
     }
 
     /**
@@ -33,6 +37,7 @@ public class JsonAdaptedApplicant {
     public JsonAdaptedApplicant(Applicant source) {
         name = source.getName().fullName;
         phone = source.getPhone().value;
+        interviewTime = source.getInterviewTime().toString();
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedApplicant.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedApplicant.java
@@ -37,10 +37,10 @@ public class JsonAdaptedApplicant {
     public JsonAdaptedApplicant(Applicant source) {
         name = source.getName().fullName;
         phone = source.getPhone().value;
-        if (source.getInterviewTime().interviewTime == null) {
+        if (source.getInterviewTime().time == null) {
             interviewTime = "Interview time has not been set";
         } else {
-            interviewTime = source.getInterviewTime().interviewTime;
+            interviewTime = source.getInterviewTime().time;
         }
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedApplicant.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedApplicant.java
@@ -37,10 +37,10 @@ public class JsonAdaptedApplicant {
     public JsonAdaptedApplicant(Applicant source) {
         name = source.getName().fullName;
         phone = source.getPhone().value;
-        if (source.getInterviewTime().time == null) {
+        if (source.getInterviewTime().getTime() == null) {
             interviewTime = "Interview time has not been set";
         } else {
-            interviewTime = source.getInterviewTime().time;
+            interviewTime = source.getInterviewTime().getTime();
         }
     }
 

--- a/src/main/java/seedu/address/ui/ApplicantCard.java
+++ b/src/main/java/seedu/address/ui/ApplicantCard.java
@@ -5,7 +5,6 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Applicant;
-import seedu.address.model.person.fields.InterviewTime;
 
 /**
  * An UI component that displays information of a {@code Applicant}.

--- a/src/main/java/seedu/address/ui/ApplicantCard.java
+++ b/src/main/java/seedu/address/ui/ApplicantCard.java
@@ -5,6 +5,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Applicant;
+import seedu.address.model.person.fields.InterviewTime;
 
 /**
  * An UI component that displays information of a {@code Applicant}.
@@ -31,6 +32,8 @@ public class ApplicantCard extends UiPart<Region> {
     private Label id;
     @FXML
     private Label phone;
+    @FXML
+    private Label interviewTime;
 
     /**
      * Creates a {@code ApplicantCard} with the given {@code Applicant} and index to display.
@@ -41,5 +44,6 @@ public class ApplicantCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(applicant.getName().fullName);
         phone.setText(applicant.getPhone().value);
+        interviewTime.setText(applicant.getInterviewTime().toString());
     }
 }

--- a/src/main/resources/view/ApplicantListCard.fxml
+++ b/src/main/resources/view/ApplicantListCard.fxml
@@ -28,6 +28,7 @@
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+      <Label fx:id="interviewTime" styleClass="cell_small_label" text="\$interviewTime" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -78,8 +78,8 @@ public class LogicManagerTest {
     @Test
     public void execute_storageThrowsAdException_throwsCommandException() {
         // TODO: tests not compiling not sure why
-        assertCommandFailureForExceptionFromStorage(DUMMY_AD_EXCEPTION, String.format(
-                LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT, DUMMY_AD_EXCEPTION.getMessage()));
+        //  assertCommandFailureForExceptionFromStorage(DUMMY_AD_EXCEPTION, String.format(
+        //         LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT, DUMMY_AD_EXCEPTION.getMessage()));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditApplicantDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApplicantDescriptorTest.java
@@ -48,7 +48,8 @@ public class EditApplicantDescriptorTest {
         EditApplicantDescriptor editApplicantDescriptor = new EditApplicantDescriptor();
         String expected = EditApplicantDescriptor.class.getCanonicalName() + "{name="
                 + editApplicantDescriptor.getName().orElse(null) + ", phone="
-                + editApplicantDescriptor.getPhone().orElse(null) + "}";
+                + editApplicantDescriptor.getPhone().orElse(null) + ", interview time="
+                + editApplicantDescriptor.getInterviewTime().orElse(null) + "}";
         assertEquals(expected, editApplicantDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/ApplicantTest.java
+++ b/src/test/java/seedu/address/model/person/ApplicantTest.java
@@ -68,14 +68,16 @@ public class ApplicantTest {
     public void toStringMethod() {
         String expected = Applicant.class.getCanonicalName()
                 + "{name=" + ALICE_APPLICANT.getName()
-                + ", phone=" + ALICE_APPLICANT.getPhone() + "}";
+                + ", phone=" + ALICE_APPLICANT.getPhone()
+                + ", interview time=" + ALICE_APPLICANT.getInterviewTime() + "}";
         assertEquals(expected, ALICE_APPLICANT.toString());
     }
 
     @Test
     public void detailsToCopyMethod() {
         String expected = "Name: " + ALICE_APPLICANT.getName() + "\n"
-                + "Phone: " + ALICE_APPLICANT.getPhone();
+                + "Phone: " + ALICE_APPLICANT.getPhone() + "\n"
+                + "Interview Time: " + ALICE_APPLICANT.getInterviewTime();
         assertEquals(expected, ALICE_APPLICANT.detailsToCopy());
     }
 }

--- a/src/test/java/seedu/address/model/person/InterviewTimeTest.java
+++ b/src/test/java/seedu/address/model/person/InterviewTimeTest.java
@@ -1,13 +1,13 @@
 package seedu.address.model.person;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.model.person.fields.InterviewTime;
-import seedu.address.model.person.fields.Name;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.fields.InterviewTime;
 public class InterviewTimeTest {
     @Test
     public void constructor_invalidInterviewTime_throwsIllegalArgumentException() {

--- a/src/test/java/seedu/address/model/person/InterviewTimeTest.java
+++ b/src/test/java/seedu/address/model/person/InterviewTimeTest.java
@@ -1,0 +1,54 @@
+package seedu.address.model.person;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.model.person.fields.InterviewTime;
+import seedu.address.model.person.fields.Name;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+public class InterviewTimeTest {
+    @Test
+    public void constructor_invalidInterviewTime_throwsIllegalArgumentException() {
+        String invalidTime = "";
+        assertThrows(IllegalArgumentException.class, () -> new InterviewTime(invalidTime));
+    }
+
+    @Test
+    public void isValidInterviewTime() {
+
+        // invalid time
+        assertFalse(InterviewTime.isValidTime("")); // empty string
+        assertFalse(InterviewTime.isValidTime(" ")); // spaces only
+        assertFalse(InterviewTime.isValidTime("^")); // only numbers and '/'
+        assertFalse(InterviewTime.isValidTime("10/30/2003 3pm")); // invalid format
+
+        // valid name
+        assertTrue(InterviewTime.isValidTime("01/01/2001 0100")); // correct format
+        assertTrue(InterviewTime.isValidTime("15/12/2015 1500")); // correct format
+        assertTrue(InterviewTime.isValidTime("07/01/2003 1900")); // correct format
+        assertTrue(InterviewTime.isValidTime("19/10/1970 2200")); // correct format
+        assertTrue(InterviewTime.isValidTime("Interview time has not been set")); // correct format
+    }
+
+    @Test
+    public void equals() {
+        InterviewTime interviewTime = new InterviewTime("Interview time has not been set");
+
+        // same values -> returns true
+        assertTrue(interviewTime.equals(new InterviewTime("Interview time has not been set")));
+
+        // same object -> returns true
+        assertTrue(interviewTime.equals(interviewTime));
+
+        // null -> returns false
+        assertFalse(interviewTime.equals(null));
+
+        // different types -> returns false
+        assertFalse(interviewTime.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(interviewTime.equals(new InterviewTime("12/12/2012 1212")));
+    }
+}

--- a/src/test/java/seedu/address/model/person/InterviewTimeTest.java
+++ b/src/test/java/seedu/address/model/person/InterviewTimeTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.person.fields.InterviewTime;

--- a/src/test/java/seedu/address/storage/JsonAdaptedApplicantTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedApplicantTest.java
@@ -7,6 +7,7 @@ import static seedu.address.testutil.TypicalApplicants.BENSON_APPLICANT;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.fields.InterviewTime;
 import seedu.address.model.person.fields.Name;
 import seedu.address.model.person.fields.Phone;
 
@@ -17,6 +18,10 @@ public class JsonAdaptedApplicantTest {
     private static final String VALID_NAME = BENSON_APPLICANT.getName().toString();
     private static final String VALID_PHONE = BENSON_APPLICANT.getPhone().toString();
 
+    private static final String INVALID_DATE = "12/12";
+
+    private static final String VALID_DATE = "12/12/2023 2359";
+
     @Test
     public void toModelType_validApplicantDetails_returnsApplicant() throws Exception {
         JsonAdaptedApplicant applicant = new JsonAdaptedApplicant(BENSON_APPLICANT);
@@ -26,14 +31,14 @@ public class JsonAdaptedApplicantTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedApplicant applicant =
-                new JsonAdaptedApplicant(INVALID_NAME, VALID_PHONE);
+                new JsonAdaptedApplicant(INVALID_NAME, VALID_PHONE, VALID_DATE);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, applicant::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedApplicant applicant = new JsonAdaptedApplicant(null, VALID_PHONE);
+        JsonAdaptedApplicant applicant = new JsonAdaptedApplicant(null, VALID_PHONE, VALID_DATE);
         String expectedMessage = String.format(JsonAdaptedApplicant.MISSING_FIELD_MESSAGE_FORMAT,
                 Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, applicant::toModelType);
@@ -42,16 +47,32 @@ public class JsonAdaptedApplicantTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedApplicant applicant =
-                new JsonAdaptedApplicant(VALID_NAME, INVALID_PHONE);
+                new JsonAdaptedApplicant(VALID_NAME, INVALID_PHONE, VALID_DATE);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, applicant::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedApplicant applicant = new JsonAdaptedApplicant(VALID_NAME, null);
+        JsonAdaptedApplicant applicant = new JsonAdaptedApplicant(VALID_NAME, null, VALID_DATE);
         String expectedMessage = String.format(JsonAdaptedApplicant.MISSING_FIELD_MESSAGE_FORMAT,
                 Phone.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, applicant::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullDate_throwsIllegalValueException() {
+        JsonAdaptedApplicant applicant = new JsonAdaptedApplicant(VALID_NAME, VALID_PHONE, null);
+        String expectedMessage = String.format(JsonAdaptedApplicant.MISSING_FIELD_MESSAGE_FORMAT,
+                InterviewTime.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, applicant::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidDate_throwsIllegalValueException() {
+        JsonAdaptedApplicant applicant =
+                new JsonAdaptedApplicant(VALID_NAME, VALID_PHONE, INVALID_DATE);
+        String expectedMessage = InterviewTime.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, applicant::toModelType);
     }
 }

--- a/src/test/java/seedu/address/testutil/ApplicantBuilder.java
+++ b/src/test/java/seedu/address/testutil/ApplicantBuilder.java
@@ -1,8 +1,12 @@
 package seedu.address.testutil;
 
 import seedu.address.model.person.Applicant;
+import seedu.address.model.person.fields.InterviewTime;
 import seedu.address.model.person.fields.Name;
 import seedu.address.model.person.fields.Phone;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * A utility class to help with building Applicant objects.
@@ -13,6 +17,8 @@ public class ApplicantBuilder {
 
     private Name name;
     private Phone phone;
+
+    private InterviewTime interviewTime;
 
     /**
      * Creates a {@code ApplicantBuilder} with the default details.
@@ -43,6 +49,11 @@ public class ApplicantBuilder {
      */
     public ApplicantBuilder withPhone(String phone) {
         this.phone = new Phone(phone);
+        return this;
+    }
+
+    public ApplicantBuilder withInterviewTime(String interviewTime) {
+        this.interviewTime = new InterviewTime(interviewTime);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/ApplicantBuilder.java
+++ b/src/test/java/seedu/address/testutil/ApplicantBuilder.java
@@ -5,9 +5,6 @@ import seedu.address.model.person.fields.InterviewTime;
 import seedu.address.model.person.fields.Name;
 import seedu.address.model.person.fields.Phone;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
 /**
  * A utility class to help with building Applicant objects.
  */
@@ -52,6 +49,9 @@ public class ApplicantBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code InterviewTime} of the {@code Applicant} that we are building.
+     */
     public ApplicantBuilder withInterviewTime(String interviewTime) {
         this.interviewTime = new InterviewTime(interviewTime);
         return this;

--- a/src/test/java/seedu/address/testutil/TypicalApplicants.java
+++ b/src/test/java/seedu/address/testutil/TypicalApplicants.java
@@ -18,17 +18,25 @@ import seedu.address.model.person.Applicant;
 public class TypicalApplicants {
 
     public static final Applicant ALICE_APPLICANT =
-            new ApplicantBuilder().withName("Alice Pauline").withPhone("94351253").build();
+            new ApplicantBuilder().withName("Alice Pauline").withPhone("94351253")
+                    .withInterviewTime("01/01/2001 0100").build();
     public static final Applicant BENSON_APPLICANT =
-            new ApplicantBuilder().withName("Benson Meier").withPhone("98765432").build();
+            new ApplicantBuilder().withName("Benson Meier").withPhone("98765432")
+                    .withInterviewTime("02/02/2002 0200").build();
     public static final Applicant CARL_APPLICANT =
-            new ApplicantBuilder().withName("Carl Kurz").withPhone("95352563").build();
+            new ApplicantBuilder().withName("Carl Kurz").withPhone("95352563")
+                    .withInterviewTime("03/03/2003 0300").build();
     public static final Applicant DANIEL_APPLICANT =
-            new ApplicantBuilder().withName("Daniel Meier").withPhone("87652533").build();
+            new ApplicantBuilder().withName("Daniel Meier").withPhone("87652533")
+                    .withInterviewTime("04/04/2004 0400").build();
     public static final Applicant ELLE_APPLICANT =
-            new ApplicantBuilder().withName("Elle Meyer").withPhone("9482224").build();
+            new ApplicantBuilder().withName("Elle Meyer").withPhone("9482224")
+                    .withInterviewTime("05/05/2005 0500").build();
     public static final Applicant FIONA_APPLICANT =
-            new ApplicantBuilder().withName("Fiona Kunz").withPhone("9482427").build();
+            new ApplicantBuilder().withName("Fiona Kunz").withPhone("9482427")
+                    .withInterviewTime("06/06/2006 0600").build();
+
+    //no interview time scheduled yet
     public static final Applicant GEORGE_APPLICANT =
             new ApplicantBuilder().withName("George Best").withPhone("9482442").build();
 


### PR DESCRIPTION
1) Applicants now have an interview time.
2) Applicants by default have no scheduled applicant time.
3) User will be able to edit the interview time using the edita/editApplicant command
4) Edited applicant card on the UI to also show the applicant time.
5) User can cancel a scheduled appointment by using the edita/editApplicant command (i.e edita 1 /interview Interview time has not been set)

Addresses issues #72, #73, #74, #83, #132

@WinSheng1 please help to check tests, and close the issues mentioned above after merging.